### PR TITLE
Fix account prediction test script

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,5 +1,7 @@
 const hre = require("hardhat");
 
+const assert = require("assert");
+
 const ENTRYPOINT_ADDRESS = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
 const FACTORY_ADDRESS = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512";
 const SALT = 12345678;
@@ -8,23 +10,35 @@ async function main() {
   const [signer0] = await hre.ethers.getSigners();
   const owner = signer0.address;
 
-  const factory = await hre.ethers.getContractAt("AccountFactory2", FACTORY_ADDRESS);
+  const factory = await hre.ethers.getContractAt(
+    "AccountFactory2",
+    FACTORY_ADDRESS
+  );
 
-  const sender = await factory.createAccount(owner, SALT);
-  const senderpredicted = await factory.getAddress(owner, SALT);
-  // Compute the account address without deploying
-  const predicted = await factory.getAddress(owner, SALT);
+  // Get the address predicted by the factory
+  const predicted = await factory.getPredictedAddress(owner, SALT);
 
-  //assert.equal(sender, senderpredicted);
-  // callStatic lets us execute the call and get its return value
-  // without submitting a transaction
-  const deployedAddress = await factory.callStatic.createAccount(owner, SALT);
+  // callStatic returns the deployment address without actually deploying
+  const callStaticAddr = await factory.callStatic.createAccount(owner, SALT);
 
-  console.log(`Sender: ${sender} Predicted: ${senderpredicted}`);
+  // ensure prediction and callStatic address match
+  assert.strictEqual(
+    predicted.toLowerCase(),
+    callStaticAddr.toLowerCase(),
+    "Predicted address mismatch"
+  );
+
+  console.log(`Predicted address : ${predicted}`);
+
+  // deploy the account
   const tx = await factory.createAccount(owner, SALT);
   await tx.wait();
 
-  console.log(`Account deployed at: ${deployedAddress}\nPredicted address : ${predicted}`);
+  // verify that code exists at the predicted address
+  const code = await hre.ethers.provider.getCode(predicted);
+  assert.notStrictEqual(code, "0x", "Account was not deployed at predicted address");
+
+  console.log(`Account deployed at: ${predicted}`);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## Summary
- update `scripts/test.js` to correctly test account address prediction
- verify predicted address matches `callStatic` deployment
- ensure account is deployed at predicted address

## Testing
- `node -c scripts/test.js`

------
https://chatgpt.com/codex/tasks/task_e_686c3ad074448325b04acb12139c839b